### PR TITLE
proposed change to the rigger to prevent crashes for already added scenes

### DIFF
--- a/library/src/main/java/com/davidstemmer/screenplay/scene/rigger/PageRigger.java
+++ b/library/src/main/java/com/davidstemmer/screenplay/scene/rigger/PageRigger.java
@@ -19,6 +19,7 @@ public class PageRigger implements Scene.Rigger {
 
     @Override
     public void layoutIncoming(ViewGroup parent, View nextView, Flow.Direction direction) {
+        if (nextView.getParent() != null)  ((ViewGroup)nextView.getParent()).removeView(nextView);
         parent.addView(nextView);
     }
 


### PR DESCRIPTION
I added this change, which addresses the crash that you get when you try to go to a Scene that exists somewhere else. I've not found any problems with it yet, but I'd like to see what your thoughts are.
