### PR TITLE
80 - replaceTo not removing all views

### DIFF
--- a/library/src/main/java/com/davidstemmer/screenplay/flow/Screenplay.java
+++ b/library/src/main/java/com/davidstemmer/screenplay/flow/Screenplay.java
@@ -56,7 +56,12 @@ public class Screenplay implements Flow.Listener {
             // Animate and tear down the current scene block.
             if (incomingScene.isStacking() || outgoingScene == null) {
                 outgoingScenes = new ArrayDeque<>();
-            } else if (nextBackstack.size() > 1) {
+            }
+            // Forward to a non-stacked scene:
+            //
+
+            else if (nextBackstack.size() > 1) {
+
                 outgoingScenes = getLastSceneBlock(trimBackstack(nextBackstack, 1));
             } else {
                 outgoingScenes = new ArrayDeque<>();


### PR DESCRIPTION
This addresses #80, where `replaceTo` was not triggering removal of all views if multiple stacked scenes were present.