### PR TITLE
update to 1.0.1 to remove bad classfiles from aar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 CHANGELOG
+
+Maintenance release, removes some outdated class files that were accidentally included in the aar
+
 ## 1.0.0 CHANGELOG
 
 **API breaks**

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ Use Maven to add Screenplay to your project:
 <dependency>
     <groupId>com.davidstemmer.screenplay</groupId>
     <artifactId>screenplay</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```groovy
-compile 'com.davidstemmer.screenplay:screenplay:1.0.0'
+compile 'com.davidstemmer.screenplay:screenplay:1.0.1'
 ```
 
 #####Flow plugin download

--- a/screenplay/gradle.properties
+++ b/screenplay/gradle.properties
@@ -20,8 +20,8 @@
 POM_NAME=screenplay
 POM_ARTIFACT_ID=screenplay
 POM_PACKAGING=aar
-VERSION_NAME=1.0.0
-VERSION_CODE=9
+VERSION_NAME=1.0.1
+VERSION_CODE=10
 GROUP=com.davidstemmer.screenplay
 POM_DESCRIPTION=A minimalist framework for View-based Android applications
 POM_URL=https://github.com/weefbellington/screenplay.git


### PR DESCRIPTION
A package was moved and then removed, but the project was never cleaned before the bintray upload so the compiled classfiles remained.